### PR TITLE
adding ability to define redirects with regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,26 @@ With custom redirects, you can move pages to new routes but still preserve the o
 }
 ```
 
+If you would like to use [nginx regex locations](https://nginx.org/en/docs/http/ngx_http_core_module.html#location) for redirects you can add the `regex` boolean:
+
+```json
+{
+  "redirects": {
+    "/old/gone/": {
+      "url": "/",
+      "status": 302
+    },
+    "/some/subfolder(.*)": {
+      "url": "https://newdomain.example.com$1",
+      "status": 301,
+      "regex": true
+    }
+  }
+}
+```
+
+as you can see in the example this is quite useful when migrating a subfolder to a new subdomain but still allowing you to keep part of the url structure.
+
 ##### Interpolating Env Var Values
 It's common to want to be able to test the frontend against various backends. The `url` key supports environment variable substitution using `${ENV_VAR_NAME}`. For instance, if there was a staging and production Heroku app for your API, you could setup the config above like the following:
 

--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -105,7 +105,7 @@ http {
   <% end %>
 
   # fallback redirects named match
-  <% redirects.each do |path, hash, regex| %>
+  <% redirects.each do |path, hash| %>
     <% if hash['regex'] %>
       location ~ <%= path %> {
         return <%= hash['status'] || 301 %> <%= hash['url'] %>;

--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -105,10 +105,16 @@ http {
   <% end %>
 
   # fallback redirects named match
-  <% redirects.each do |path, hash| %>
-    location @<%= path %> {
-      return <%= hash['status'] || 301 %> <%= hash['url'] %>;
-    }
+  <% redirects.each do |path, hash, regex| %>
+    <% if hash['regex'] %>
+      location ~ <%= path %> {
+        return <%= hash['status'] || 301 %> <%= hash['url'] %>;
+      }
+    <% else %>
+      location @<%= path %> {
+        return <%= hash['status'] || 301 %> <%= hash['url'] %>;
+      }
+    <% end %>
   <% end %>
 
   }


### PR DESCRIPTION
> Fixes #92
>
> I have implemented an example repo that is using this fork of the buildpack and it is working exactly as expected.
>
> You can see a (silly) index page that explains what is going on here: static-test-mansona.herokuapp.com
>
> Essentially what it allows you to do is to define indvidual rules as regex as you see fit, this way you can make full use of wildcards and domain redirects. Here is an example config:
>
> ```
> {
>  "root": "public_html",
>  "clean_urls": true,
>  "redirects": {
>    "/standard/": {
>      "url": "https://heroku.com",
>      "status": 302
>    },
>    "/magic(.*)": {
>      "url": "https://stonecircle.io$1",
>      "regex": true
>    }
>  }
> } 
> ```
>
> As you can see that if you visit static-test-mansona.herokuapp.com/magic/opensource it will redirect you to stonecircle.io/opensource 👍

 -- @mansona

See https://github.com/heroku/heroku-buildpack-static/pull/105/files