### PR TITLE
fix: Gemfile.lock & Gemfile to reduce vulnerabilities

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 group :development do
   gem "rake"
-  gem "docker-api"
+  gem "docker-api", ">= 1.33.1"
   gem "rspec"
   gem "concurrent-ruby"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,11 +4,11 @@ GEM
     concurrent-ruby (0.8.0)
       ref (~> 1.0, >= 1.0.5)
     diff-lcs (1.2.5)
-    docker-api (1.33.1)
-      excon (>= 0.38.0)
-      json
-    excon (0.54.0)
-    json (2.0.2)
+    docker-api (1.34.2)
+      excon (>= 0.47.0)
+      multi_json
+    excon (0.62.0)
+    multi_json (1.13.1)
     rake (10.4.0)
     ref (1.0.5)
     rspec (3.2.0)
@@ -30,9 +30,9 @@ PLATFORMS
 
 DEPENDENCIES
   concurrent-ruby
-  docker-api
+  docker-api (>= 1.33.1)
   rake
   rspec
 
 BUNDLED WITH
-   1.13.6
+   1.16.1


### PR DESCRIPTION
The following vulnerabilities are fixed with an upgrade:
- https://snyk.io/vuln/SNYK-RUBY-EXCON-20404

See https://github.com/heroku/heroku-buildpack-static/pull/102